### PR TITLE
fix type restriction on Area#on_key_event

### DIFF
--- a/src/iu/components/area.cr
+++ b/src/iu/components/area.cr
@@ -45,7 +45,7 @@ module Iu
       abstract def on_mouse_event(mouse_event : UI::AreaMouseEvent)
       abstract def on_mouse_crossed(left : Bool)
       abstract def on_drag_broken
-      abstract def on_key_event(key_event : UI::AreaKeyEvent) : Int32
+      abstract def on_key_event(key_event : UI::AreaKeyEvent)
 
       def set_size(width : Int32, height : Int32)
         UI.area_set_size(@area, width, height)


### PR DESCRIPTION
The `on_key_event` function is restricted to Int32 in the base Area class. However, the Area class itself makes an attempt to cast that Int32 to nil, which is impossible, causing a compilation failure. This PR simply removes the type restriction on on_key_event, as that seems to have completely fixed the problem in my local copy.